### PR TITLE
Updates Molecule workflow for Ubuntu 22.04

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -17,8 +17,8 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          python -m pip install --disable-pip-version-check editorconfig-checker
-          python -m pip install --disable-pip-version-check ansible ansible-lint molecule[docker,lint,test]
+          python -m pip install --disable-pip-version-check editorconfig-checker flake8 pytest testinfra
+          python -m pip install --disable-pip-version-check ansible ansible-lint molecule yamllint molecule-plugins[docker]
 
       - name: Run Molecule tests
         run: |

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -22,8 +22,9 @@ platforms:
       - /run
       - /tmp
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
+    cgroupns_mode: host
 
 provisioner:
   name: ansible


### PR DESCRIPTION
This is mostly pipe fitting to get CI/CD tests to pass again on Ubuntu 22.04 runners. Also adds missing PIP dependencies introduced since version Molecule 5.0+.

[Further discussion can be found here with regards to permission changes to cgroup volume](https://github.com/moby/moby/issues/42275).